### PR TITLE
ModuleState populates resource/datasource TF state

### DIFF
--- a/cmd/terrafix/main.go
+++ b/cmd/terrafix/main.go
@@ -28,10 +28,10 @@ type FlagSet struct {
 
 func main() {
 	var fset FlagSet
-	flag.StringVar(&fset.ProviderAddr, "provider-addr", "", "fully qualified provider address")
-	flag.StringVar(&fset.ProviderPath, "provider-path", "", "path to the target provider executable")
-	flag.StringVar(&fset.Output, "output", "", "the output folder where the updated configs will be written to (by default writes to the stdout)")
-	flag.StringVar(&fset.LogLevel, "log-level", hclog.Error.String(), "log level")
+	flag.StringVar(&fset.ProviderAddr, "provider-addr", "", "The fully qualified provider address (e.g. registry.terraform.io/hashicorp/azurerm)")
+	flag.StringVar(&fset.ProviderPath, "provider-path", "", "The path to the target provider executable")
+	flag.StringVar(&fset.Output, "output", "", "The output folder where the updated configs will be written to (by default writes to the stdout)")
+	flag.StringVar(&fset.LogLevel, "log-level", hclog.Error.String(), "The log level")
 	flag.Usage = func() {
 		fmt.Fprint(os.Stderr, `usage: terrafix [options] root-module-path
 

--- a/internal/fixer/fixer.go
+++ b/internal/fixer/fixer.go
@@ -34,6 +34,8 @@ type FixDefinitionRequest struct {
 	Version   int
 	// The raw HCL content of this block definition
 	RawContent []byte
+	// The Terraform state (only available for resource and data source)
+	State []byte
 }
 
 type FixDefinitionResponse struct {

--- a/internal/state/root_state_test.go
+++ b/internal/state/root_state_test.go
@@ -355,3 +355,29 @@ func TestRootStateDecoder(t *testing.T) {
 		})
 	}
 }
+
+func TestNewRootStatePopulateTFState(t *testing.T) {
+	rootModPath := "testdata/nested_modules"
+	tfpath, err := find.FindTF(context.Background(), version.MustConstraints(version.NewConstraint(">=1.0.0")))
+	require.NoError(t, err)
+	tf, err := tfexec.NewTerraform(rootModPath, tfpath)
+	require.NoError(t, err)
+
+	fs, err := filesystem.NewMemFS(rootModPath, nil)
+	require.NoError(t, err)
+
+	root, err := state.NewRootState(tf, fs, rootModPath)
+	require.NoError(t, err)
+
+	mod0 := root.ModuleStates["testdata/nested_modules"]
+	require.Len(t, mod0.TFStateResources, 1)
+	require.NotNil(t, mod0.TFStateResources["data.azurerm_resource_group.test"])
+	mod1 := root.ModuleStates["testdata/nested_modules/module"]
+	require.Len(t, mod1.TFStateResources, 2)
+	require.NotNil(t, mod1.TFStateResources["azurerm_resource_group.test"])
+	require.NotNil(t, mod1.TFStateResources["data.azurerm_resource_group.test"])
+	mod2 := root.ModuleStates["testdata/nested_modules/module/module"]
+	require.Len(t, mod2.TFStateResources, 2)
+	require.NotNil(t, mod2.TFStateResources["azurerm_resource_group.test"])
+	require.NotNil(t, mod2.TFStateResources["data.azurerm_resource_group.test"])
+}

--- a/internal/state/testdata/nested_modules/main.tf
+++ b/internal/state/testdata/nested_modules/main.tf
@@ -1,0 +1,21 @@
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+resource "azurerm_resource_group" "test" {
+  count    = 2
+  name     = "terrafix-test-${count.index}"
+  location = "westus2"
+}
+
+data "azurerm_resource_group" "test" {
+  name = azurerm_resource_group.test[0].name
+}
+
+module "test" {
+  source = "./module"
+}

--- a/internal/state/testdata/nested_modules/module/main.tf
+++ b/internal/state/testdata/nested_modules/module/main.tf
@@ -1,0 +1,12 @@
+resource "azurerm_resource_group" "test" {
+  name     = "terrafix-test-mod"
+  location = "westus2"
+}
+
+data "azurerm_resource_group" "test" {
+  name = azurerm_resource_group.test.name
+}
+
+module "test" {
+  source = "./module"
+}

--- a/internal/state/testdata/nested_modules/module/module/main.tf
+++ b/internal/state/testdata/nested_modules/module/module/main.tf
@@ -1,0 +1,8 @@
+resource "azurerm_resource_group" "test" {
+  name     = "terrafix-test-mod-mod"
+  location = "westus2"
+}
+
+data "azurerm_resource_group" "test" {
+  name = azurerm_resource_group.test.name
+}

--- a/internal/state/testdata/nested_modules/terraform.tfstate
+++ b/internal/state/testdata/nested_modules/terraform.tfstate
@@ -1,0 +1,161 @@
+{
+  "version": 4,
+  "terraform_version": "1.9.0",
+  "serial": 18,
+  "lineage": "ae701d46-cf11-a0e7-1c25-f833c97ffa73",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "data",
+      "type": "azurerm_resource_group",
+      "name": "test",
+      "provider": "provider[\"registry.terraform.io/hashicorp/azurerm\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "/subscriptions/sub1/resourceGroups/terrafix-test-0",
+            "location": "westus2",
+            "managed_by": "",
+            "name": "terrafix-test-0",
+            "tags": {},
+            "timeouts": null
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "azurerm_resource_group",
+      "name": "test",
+      "provider": "provider[\"registry.terraform.io/hashicorp/azurerm\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "id": "/subscriptions/sub1/resourceGroups/terrafix-test-0",
+            "location": "westus2",
+            "managed_by": "",
+            "name": "terrafix-test-0",
+            "tags": {},
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo1NDAwMDAwMDAwMDAwLCJkZWxldGUiOjU0MDAwMDAwMDAwMDAsInJlYWQiOjMwMDAwMDAwMDAwMCwidXBkYXRlIjo1NDAwMDAwMDAwMDAwfX0="
+        },
+        {
+          "index_key": 1,
+          "schema_version": 0,
+          "attributes": {
+            "id": "/subscriptions/sub1/resourceGroups/terrafix-test-1",
+            "location": "westus2",
+            "managed_by": "",
+            "name": "terrafix-test-1",
+            "tags": {},
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo1NDAwMDAwMDAwMDAwLCJkZWxldGUiOjU0MDAwMDAwMDAwMDAsInJlYWQiOjMwMDAwMDAwMDAwMCwidXBkYXRlIjo1NDAwMDAwMDAwMDAwfX0="
+        }
+      ]
+    },
+    {
+      "module": "module.test",
+      "mode": "data",
+      "type": "azurerm_resource_group",
+      "name": "test",
+      "provider": "provider[\"registry.terraform.io/hashicorp/azurerm\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "/subscriptions/sub1/resourceGroups/terrafix-test-mod",
+            "location": "westus2",
+            "managed_by": "",
+            "name": "terrafix-test-mod",
+            "tags": {
+              "Creator": "3fcd80dd-806c-41fb-a1b2-f4db1769e409",
+              "DateCreated": "2024-09-27T06:56:50Z"
+            },
+            "timeouts": null
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.test",
+      "mode": "managed",
+      "type": "azurerm_resource_group",
+      "name": "test",
+      "provider": "provider[\"registry.terraform.io/hashicorp/azurerm\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "/subscriptions/sub1/resourceGroups/terrafix-test-mod",
+            "location": "westus2",
+            "managed_by": "",
+            "name": "terrafix-test-mod",
+            "tags": {},
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo1NDAwMDAwMDAwMDAwLCJkZWxldGUiOjU0MDAwMDAwMDAwMDAsInJlYWQiOjMwMDAwMDAwMDAwMCwidXBkYXRlIjo1NDAwMDAwMDAwMDAwfX0="
+        }
+      ]
+    },
+    {
+      "module": "module.test.module.test",
+      "mode": "data",
+      "type": "azurerm_resource_group",
+      "name": "test",
+      "provider": "provider[\"registry.terraform.io/hashicorp/azurerm\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "/subscriptions/sub1/resourceGroups/terrafix-test-mod-mod",
+            "location": "westus2",
+            "managed_by": "",
+            "name": "terrafix-test-mod-mod",
+            "tags": {
+              "Creator": "3fcd80dd-806c-41fb-a1b2-f4db1769e409",
+              "DateCreated": "2024-09-27T07:43:59Z"
+            },
+            "timeouts": null
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.test.module.test",
+      "mode": "managed",
+      "type": "azurerm_resource_group",
+      "name": "test",
+      "provider": "provider[\"registry.terraform.io/hashicorp/azurerm\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "/subscriptions/sub1/resourceGroups/terrafix-test-mod-mod",
+            "location": "westus2",
+            "managed_by": "",
+            "name": "terrafix-test-mod-mod",
+            "tags": {
+              "Creator": "3fcd80dd-806c-41fb-a1b2-f4db1769e409",
+              "DateCreated": "2024-09-27T07:43:59Z"
+            },
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo1NDAwMDAwMDAwMDAwLCJkZWxldGUiOjU0MDAwMDAwMDAwMDAsInJlYWQiOjMwMDAwMDAwMDAwMCwidXBkYXRlIjo1NDAwMDAwMDAwMDAwfX0="
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}


### PR DESCRIPTION
Adds a new field in the `ModuleState`, named `TFResources`. This field contains the resource/data source Terraform states that belong to this module.

It only populates these states if:

- There is a terraform.tfstate file existing at the root module folder
- The absolute address of the resource/data source doesn't include any *index*, either at the module level, or the resource level. E.g. `module.test[0].azurerm_subnet.test` or `azurerm_subnet.test[0]` won't be populated, but `module.test.azurerm_subnet.test` will

Fix #2